### PR TITLE
Properly deploys to heroku

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -1,0 +1,13 @@
+if (process.env.NODE_ENV === 'production') {
+
+  // We basically just create a child process that will run
+  // the production bundle command
+  var child_process = require('child_process');
+  child_process.exec("webpack -p --config webpack.prod.config.js", function (error, stdout, stderr) {
+    console.log('stdout: ' + stdout);
+    console.log('stderr: ' + stderr);
+    if (error !== null) {
+      console.log('exec error: ' + error);
+    }
+  });
+}

--- a/package.json
+++ b/package.json
@@ -21,15 +21,15 @@
     "mongoose": "^4.9.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "request": "^2.81.0",
-    "webpack": "^2.2.1",
-    "babel-cli": "^6.7.5",
-    "babel-loader": "^6.4.0"
+    "request": "^2.81.0"
   },
   "devDependencies": {
     "babel-preset-react": "^6.23.0",
+    "babel-loader": "^6.4.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.7.2",
+    "babel-cli": "^6.7.5",
+    "webpack": "^2.2.1",
     "eslint-config-hackreactor": "git://github.com/reactorcore/eslint-config-hackreactor"
   },
   "babel": {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "request": "^2.81.0",
-    "webpack": "^2.2.1"
+    "webpack": "^2.2.1",
+    "babel-loader": "^6.4.0"
   },
   "devDependencies": {
     "babel-preset-react": "^6.23.0",
-    "babel-loader": "^6.4.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.7.2",
     "babel-cli": "^6.7.5",

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "react-dom": "^15.4.2",
     "request": "^2.81.0",
     "webpack": "^2.2.1",
+    "babel-cli": "^6.7.5",
     "babel-loader": "^6.4.0"
   },
   "devDependencies": {
     "babel-preset-react": "^6.23.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.7.2",
-    "babel-cli": "^6.7.5",
     "eslint-config-hackreactor": "git://github.com/reactorcore/eslint-config-hackreactor"
   },
   "babel": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "mongoose": "^4.9.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "request": "^2.81.0"
+    "request": "^2.81.0",
+    "webpack": "^2.2.1"
   },
   "devDependencies": {
     "babel-preset-react": "^6.23.0",
@@ -29,7 +30,6 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.7.2",
     "babel-cli": "^6.7.5",
-    "webpack": "^2.2.1",
     "eslint-config-hackreactor": "git://github.com/reactorcore/eslint-config-hackreactor"
   },
   "babel": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "dev": "webpack -d --watch",
     "build": "webpack -p",
-    "start": "node server/server.js"
+    "start": "node server/server.js",
+    "postinstall": "node deploy.js"
   },
   "dependencies": {
     "body-parser": "^1.17.1",

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -5,7 +5,7 @@ var BUILD_DIR = path.resolve(__dirname, 'client/public');
 var APP_DIR = path.resolve(__dirname, 'client/app/components');
 
 var config = {
-  // devtool: 'source-map',
+  devtool: 'source-map',
   entry: APP_DIR + '/index.jsx',
   output: {
     path: BUILD_DIR,

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -1,0 +1,25 @@
+var webpack = require('webpack');
+var path = require('path');
+
+var BUILD_DIR = path.resolve(__dirname, 'client/public');
+var APP_DIR = path.resolve(__dirname, 'client/app/components');
+
+var config = {
+  // devtool: 'source-map',
+  entry: APP_DIR + '/index.jsx',
+  output: {
+    path: BUILD_DIR,
+    filename: 'bundle.js'
+  },
+  module : {
+    loaders : [
+      {
+        test : /\.jsx?/,
+        include : APP_DIR,
+        loader : 'babel-loader'
+      }
+    ]
+  }
+};
+
+module.exports = config;


### PR DESCRIPTION
Temporary workaround so that we can constantly see our website.
Set NPM_CONFIG_PRODUCTION to false in heroku so that it installs all dependencies (includes the dev dependencies).

deploy.js is called only in heroku when it does npm's postinstall script.
It configures webpack to use webpack.prod.config.js instead of webpack.config.js.

It may not have been necessary to include these files if i disabled the npm_config_production earlier, but I am just leaving them in in case I figure out how to have it use webpack without the dev dependency.

The staging repo for the heroku app is https://git.heroku.com/sf-safewalk-staging.git

git remote add staging https://git.heroku.com/sf-safewalk-staging.git

if you git remote add it, you can then push to staging by writing:

git push staging master

If you then go to heroku.com I have added you all to the application. You can push the staged version to production there. I can go over this more tomorrow!

But it's currently up and running with tyler's code!

https://sf-safewalk.herokuapp.com/