### PR TITLE
Feat/clear database

### DIFF
--- a/client/app/components/gmap.jsx
+++ b/client/app/components/gmap.jsx
@@ -47,7 +47,7 @@ class Gmap extends React.Component {
   overlayHeatmap() {
 
     var heatmapPoints = this.props.heatmapData.map(function(crime) {
-      return new google.maps.LatLng(crime.location.coordinates[1] - 0, crime.location.coordinates[0] - 0);
+      return new google.maps.LatLng(crime.location.coordinates[0] - 0, crime.location.coordinates[1] - 0);
     });
 
     // Google heatmap layer has upper limites so we can't render all at once for right now
@@ -55,7 +55,7 @@ class Gmap extends React.Component {
 
     var heatmap = new google.maps.visualization.HeatmapLayer({
       data: heatmapSlice,
-      radius: 30,
+      radius: 20,
       map: this.state.map
     });
 

--- a/client/app/components/index.jsx
+++ b/client/app/components/index.jsx
@@ -62,7 +62,7 @@ class App extends React.Component {
         address: address
       }),
       success: function (data) {
-        callback(JSON.parse(data));
+        callback(data);
       },
       error: function(err) {
         console.log(err);

--- a/server/models/crime.js
+++ b/server/models/crime.js
@@ -27,8 +27,13 @@ var storeOpenData = (crimeData, callback) => {
 
 module.exports.storeOpenData = storeOpenData;
 
+var clearDatabase = (callback) => {
+  Crime.remove({}, function(err) {
+    callback();
+  });
+};
 
-
+module.exports.clearDatabase = clearDatabase;
 
 var findAll = (callback) => {
   Crime.find({}, function(err, results) {

--- a/server/models/crime.js
+++ b/server/models/crime.js
@@ -25,15 +25,11 @@ var storeOpenData = (crimeData, callback) => {
   });
 }
 
-module.exports.storeOpenData = storeOpenData;
-
 var clearDatabase = (callback) => {
   Crime.remove({}, function(err) {
     callback();
   });
 };
-
-module.exports.clearDatabase = clearDatabase;
 
 var findAll = (callback) => {
   Crime.find({}, function(err, results) {
@@ -45,9 +41,6 @@ var findAll = (callback) => {
   });
 };
 
-module.exports.findAll = findAll;
-
-
 var findLocations = (callback) => {
   Crime.find({}, 'location.coordinates -_id', function(err, results) {
     if (err) {
@@ -58,4 +51,7 @@ var findLocations = (callback) => {
   });
 };
 
+module.exports.storeOpenData = storeOpenData;
+module.exports.clearDatabase = clearDatabase;
 module.exports.findLocations = findLocations;
+module.exports.findAll = findAll;

--- a/server/workers/openDataCaller.js
+++ b/server/workers/openDataCaller.js
@@ -6,12 +6,14 @@ request('https://data.sfgov.org/resource/9v2m-8wqu.json', function(err, res, bod
   if (err) {
     console.log(err);
   } else {
-    var results = JSON.parse(body);
-    db.storeOpenData(results, function(err) {
-      if (err) {
-        console.error(err);
-      }
-    })
+    db.clearDatabase(function(err) {
+      var results = JSON.parse(body);
+      db.storeOpenData(results, function(err) {
+        if (err) {
+          console.error(err);
+        }
+      });
+    });
   }
 });
 


### PR DESCRIPTION
I switched the latitude and longitude but I'm not sure why I had to. Could it be that clearing the database makes it this way? Also don't need to parse the data from the ajax call because it is already parsed in mapsHelper.js.

Every time server restarts it will clear database and fetch the 1000 results. Let me know if this breaks for you guys.