### PR TITLE
Feat/draggableroutes

### DIFF
--- a/client/app/components/directions.jsx
+++ b/client/app/components/directions.jsx
@@ -13,9 +13,13 @@ class Directions extends React.Component {
     var directionsService = new google.maps.DirectionsService();
     var directionsDisplay = new google.maps.DirectionsRenderer({
       draggable: true,
-      suppressPolylines: true
+      //suppressPolylines: true
     });
     directionsDisplay.setPanel(document.getElementById('directionsPanel'));
+    directionsDisplay.addListener('directions_changed', () => {
+      let directions = directionsDisplay.directions;
+      this.props.getCrimeData(directions.routes[0].legs[0].steps);
+    })
     this.setState({
       directionsService: directionsService,
       directionsDisplay: directionsDisplay
@@ -45,12 +49,12 @@ class Directions extends React.Component {
     var request = {
       origin: start,
       destination: end,
-      travelMode: 'WALKING',
+      travelMode: 'DRIVING',
+      avoidHighways: true,
       provideRouteAlternatives: true
     };
     this.state.directionsService.route(request, (response, status) => {
       if (status === 'OK') {
-        this.props.getCrimeData(response.routes[0].legs[0].steps);
         this.state.directionsDisplay.setDirections(response);
       }
     })
@@ -59,7 +63,7 @@ class Directions extends React.Component {
   drawLine(origin, destination, rating) {
     let options = {
       strokeColor: rating,
-      strokeOpacity: 0.5,
+      strokeOpacity: 0.75,
       strokeWeight: 3
     }
 
@@ -74,7 +78,8 @@ class Directions extends React.Component {
     let request = {
       origin: origin,
       destination: destination,
-      travelMode: 'WALKING'
+      travelMode: 'DRIVING',
+      avoidHighways: true
     };
 
     this.state.directionsService.route(request, (response, status) => {

--- a/client/app/components/directions.jsx
+++ b/client/app/components/directions.jsx
@@ -19,11 +19,12 @@ class Directions extends React.Component {
       }
     });
     directionsDisplay.setPanel(document.getElementById('directionsPanel'));
-    directionsDisplay.addListener('directions_changed', () => {
+    directionsDisplay.addListener('routeindex_changed', () => {
       this.clearLines();
       let directions = directionsDisplay.directions;
-      this.props.getCrimeData(directions.routes[0].legs[0].steps);
-    })
+      let routeIndex = directionsDisplay.getRouteIndex();
+      this.props.getCrimeData(directions.routes[routeIndex].legs[0].steps);
+    });
     this.setState({
       directionsService: directionsService,
       directionsDisplay: directionsDisplay

--- a/client/app/components/directions.jsx
+++ b/client/app/components/directions.jsx
@@ -5,7 +5,8 @@ class Directions extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      origDest: null
+      origDest: null,
+      lines: []
     };
   }
 
@@ -13,10 +14,13 @@ class Directions extends React.Component {
     var directionsService = new google.maps.DirectionsService();
     var directionsDisplay = new google.maps.DirectionsRenderer({
       draggable: true,
-      //suppressPolylines: true
+      polylineOptions: {
+        strokeOpacity: 0.25
+      }
     });
     directionsDisplay.setPanel(document.getElementById('directionsPanel'));
     directionsDisplay.addListener('directions_changed', () => {
+      this.clearLines();
       let directions = directionsDisplay.directions;
       this.props.getCrimeData(directions.routes[0].legs[0].steps);
     })
@@ -64,7 +68,7 @@ class Directions extends React.Component {
     let options = {
       strokeColor: rating,
       strokeOpacity: 0.75,
-      strokeWeight: 3
+      strokeWeight: 5
     }
 
     let dirRenderer = new google.maps.DirectionsRenderer({
@@ -73,6 +77,7 @@ class Directions extends React.Component {
       preserveViewport: true
     })
 
+    this.state.lines.push(dirRenderer);
     dirRenderer.setMap(this.props.map);
 
     let request = {
@@ -86,6 +91,12 @@ class Directions extends React.Component {
       if (status === 'OK') {
         dirRenderer.setDirections(response);
       }
+    })
+  }
+
+  clearLines() {
+    this.state.lines.forEach((line) => {
+      line.setMap(null);
     })
   }
 

--- a/client/app/components/index.jsx
+++ b/client/app/components/index.jsx
@@ -50,7 +50,6 @@ class App extends React.Component {
     let coords = steps.map((step) => {
       return [[step.start_location.lng(), step.start_location.lat()], [step.end_location.lng(), step.end_location.lat()]]
     });
-    //function to send POST request to server once server-side routes are written
     axios.post('/ratings', {streets: coords})
       .then((res) => {
         this.setState({


### PR DESCRIPTION
Hey all - this PR completes the following client-side tickets:
-Allow user to drag directions line to create a new route and re-render crime lines accordingly
-Add street coloring for alternative routes provided by google maps
-Remove street lines for every new search
-Change opacity of street lines to make them more readable

This PR shouldn't conflict with any outstanding pull requests because it doesn't touch any server-side files! Also, in case you were wondering, I changed the directions routing to 'driving' so we would avoid routes that went indoors/used pedestrian paths.
